### PR TITLE
Add ability to update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Test output will be on the command line.
   "endpoint": "/cheese",
   "methods": ["GET"],
   "status_code": 200,
-  "json_response": "{"type": "cheese"}"
+  "json_response": {"type": "cheese"}
 }
 ``` 
 

--- a/app.py
+++ b/app.py
@@ -35,6 +35,11 @@ def register():
     # TODO headers = parsed_json['headers']
     json_response = parsed_json['json_response']
 
+    for rule in app.url_map.iter_rules():
+        if rule.rule == endpoint:
+            # Accessing private isn't nice. Raise PR with Werkzeug to support deleting endpoints?
+            app.url_map._rules.remove(rule)
+
     def func():
         response = jsonify(json_response)
         response.status_code = status_code

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -76,6 +76,40 @@ class IntegrationTest(unittest.TestCase):
         response = self.app.get('/non_standard')
         assert response.status_code == 300
 
+    def test_update_endpoint(self):
+
+        # Setup endpoint
+        payload = {
+            "endpoint": "/endpoint_to_update",
+            "methods": ["GET"],
+            "status_code": 200,
+            "json_response": {'cheese_flavour': 'cheddar'}
+        }
+
+        json_payload = json.dumps(payload)
+
+        self.app.post('/register', data=json_payload, headers={'content-type': 'application/json'})
+
+        response = self.app.get('/endpoint_to_update')
+        assert response.json['cheese_flavour'] == 'cheddar'
+        assert response.status_code == 200
+
+        # Setup endpoint with a different response
+        payload = {
+            "endpoint": "/endpoint_to_update",
+            "methods": ["GET"],
+            "status_code": 200,
+            "json_response": {'cheese_flavour': 'gouda'}
+        }
+
+        json_payload = json.dumps(payload)
+
+        self.app.post('/register', data=json_payload, headers={'content-type': 'application/json'})
+
+        response = self.app.get('/endpoint_to_update')
+        assert response.status_code == 200
+        assert response.json['cheese_flavour'] == 'gouda'
+
     def test_get_code(self):
         response = self.app.get('/get_code')
         assert response.status_code == 200


### PR DESCRIPTION
Add ability to update endpoints. Accesses a private variable which isn't nice...but Werkzeug does not support deleting endpoints. Might be worth raising a PR with them to support deletion?