### PR TITLE
Added paginated / iterable endpoint responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,19 @@ Test output will be on the command line.
   "endpoint": "/cheese",
   "methods": ["GET"],
   "status_code": 200,
-  "json_response": {"type": "cheese"}
+  "json_response": [{"type": "cheese"}]
 }
 ``` 
+
+* Iterable responses are supported, so you can have an endpoint return something different each time it has been called up to the last json response you specify
+```json
+{
+  "endpoint": "/cheese",
+  "methods": ["GET"],
+  "status_code": 200,
+  "json_response": [{"type": "cheese"}, {"type": "gouda"}]
+}
+```
 
 * List all endpoints by sending a request to `/list`
 * Shutdown the app by sending a request to `/shutdown` 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,7 @@ class IntegrationTest(unittest.TestCase):
             "endpoint": "/post_test",
             "methods": ["POST"],
             "status_code": 200,
-            "json_response": {}
+            "json_responses": [{}]
         }
 
         json_payload = json.dumps(payload)
@@ -26,13 +26,14 @@ class IntegrationTest(unittest.TestCase):
         response = self.app.post('/post_test')
         assert response.status_code == 200
 
+
     def test_get_returns_200(self):
 
         payload = {
             "endpoint": "/cheese",
             "methods": ["GET"],
             "status_code": 200,
-            "json_response": {}
+            "json_responses": [{}]
         }
 
         json_payload = json.dumps(payload)
@@ -48,7 +49,7 @@ class IntegrationTest(unittest.TestCase):
             "endpoint": "/json_test",
             "methods": ["GET"],
             "status_code": 200,
-            "json_response": {'cheese_flavour': 'cheddar'}
+            "json_responses": [{'cheese_flavour': 'cheddar'}]
         }
 
         json_payload = json.dumps(payload)
@@ -66,7 +67,7 @@ class IntegrationTest(unittest.TestCase):
             "endpoint": "/non_standard",
             "methods": ["GET"],
             "status_code": 300,
-            "json_response": {'cheese_flavour': 'cheddar'}
+            "json_responses": [{'cheese_flavour': 'cheddar'}]
         }
 
         json_payload = json.dumps(payload)
@@ -83,7 +84,7 @@ class IntegrationTest(unittest.TestCase):
             "endpoint": "/endpoint_to_update",
             "methods": ["GET"],
             "status_code": 200,
-            "json_response": {'cheese_flavour': 'cheddar'}
+            "json_responses": [{'cheese_flavour': 'cheddar'}]
         }
 
         json_payload = json.dumps(payload)
@@ -99,7 +100,7 @@ class IntegrationTest(unittest.TestCase):
             "endpoint": "/endpoint_to_update",
             "methods": ["GET"],
             "status_code": 200,
-            "json_response": {'cheese_flavour': 'gouda'}
+            "json_responses": [{'cheese_flavour': 'gouda'}]
         }
 
         json_payload = json.dumps(payload)
@@ -125,6 +126,54 @@ class IntegrationTest(unittest.TestCase):
         assert response.status_code == 200
         json_response = json.loads(response.data)
         assert json_response['keys']
+
+    def test_pagination_support(self):
+
+        payload = {
+            "endpoint": "/post_test",
+            "methods": ["POST"],
+            "status_code": 200,
+            "json_responses": [{'cheese_flavour': 'cheddar'}, {'cheese_flavour': 'gouda'}]
+        }
+
+        json_payload = json.dumps(payload)
+
+        self.app.post('/register', data=json_payload, headers={'content-type': 'application/json'})
+
+        response = self.app.post('/post_test')
+        assert response.status_code == 200
+
+        json_response = json.loads(response.data)
+        assert json_response['cheese_flavour'] == 'cheddar'
+
+        second_response = self.app.post('/post_test')
+
+        second_response = json.loads(second_response.data)
+        assert second_response['cheese_flavour'] == 'gouda'
+
+        third_response = self.app.post('/post_test')
+
+        third_response = json.loads(third_response.data)
+        assert third_response['cheese_flavour'] == 'gouda'
+
+    def test_pagination_register_no_list_object(self):
+
+        payload = {
+            "endpoint": "/post_test",
+            "methods": ["POST"],
+            "status_code": 200,
+            "json_responses": []
+        }
+
+        json_payload = json.dumps(payload)
+
+        response = self.app.post('/register', data=json_payload, headers={'content-type': 'application/json'})
+        assert response.status_code == 200
+
+        created_endpoint_response = self.app.post('/post_test')
+        assert created_endpoint_response.status_code == 200
+        json_response = json.loads(created_endpoint_response.data)
+        assert json_response == {}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds the ability to have multiple responses against one endpoint that you've setup. 

We now have to send an array of JSON responses but it will function the same if only one response object is set.

This change is to allow for a catch all solution to testing paginated responses. 